### PR TITLE
Add URL arguments on get methods

### DIFF
--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		344FC72F1FE5DA4200958CE4 /* Result+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC72A1FE5DA0300958CE4 /* Result+Data.swift */; };
 		34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */; };
 		34F9C72C1FE89F44002C1EB0 /* QueryItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */; };
+		579F534B200151B700E9996A /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579F5349200151B300E9996A /* Empty.swift */; };
+		579F534E200151DF00E9996A /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579F534C200151D700E9996A /* MockURLSession.swift */; };
+		579F53512001525100E9996A /* SomeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579F534F2001521300E9996A /* SomeError.swift */; };
 		OBJ_21 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_27 /* NetworkGetterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* NetworkGetterTests.swift */; };
 		OBJ_29 /* Frisbee.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Frisbee::Frisbee::Product" /* Frisbee.framework */; };
@@ -82,6 +85,9 @@
 		344FC72C1FE5DA2C00958CE4 /* Error+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Equatable.swift"; sourceTree = "<group>"; };
 		34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilderTests.swift; sourceTree = "<group>"; };
 		34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilder.swift; sourceTree = "<group>"; };
+		579F5349200151B300E9996A /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
+		579F534C200151D700E9996A /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		579F534F2001521300E9996A /* SomeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeError.swift; sourceTree = "<group>"; };
 		"Frisbee::Frisbee::Product" /* Frisbee.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Frisbee.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Frisbee::FrisbeeTests::Product" /* FrisbeeTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = FrisbeeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_12 /* NetworkGetterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGetterTests.swift; sourceTree = "<group>"; };
@@ -199,6 +205,16 @@
 			path = Tests/FrisbeeTests/Interactors;
 			sourceTree = SOURCE_ROOT;
 		};
+		579F5348200151A300E9996A /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				579F5349200151B300E9996A /* Empty.swift */,
+				579F534C200151D700E9996A /* MockURLSession.swift */,
+				579F534F2001521300E9996A /* SomeError.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		OBJ_10 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -212,6 +228,7 @@
 			children = (
 				344FC7211FE5BDAE00958CE4 /* Extensions */,
 				3434A0B71FE7DBA8000659E5 /* Factories */,
+				579F5348200151A300E9996A /* Helpers */,
 				3434A0BD1FE7DFEF000659E5 /* Integration */,
 				34F9C7241FE895F6002C1EB0 /* Interactors */,
 				344FC7321FE5DFD400958CE4 /* Requestables */,
@@ -383,13 +400,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				579F534E200151DF00E9996A /* MockURLSession.swift in Sources */,
 				3434A0BF1FE7E025000659E5 /* IntegrationNetworkGetTests.swift in Sources */,
 				3434A0BA1FE7DC30000659E5 /* URLRequestFactoryTests.swift in Sources */,
+				579F53512001525100E9996A /* SomeError.swift in Sources */,
 				344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */,
 				344FC72E1FE5DA3D00958CE4 /* Error+Equatable.swift in Sources */,
 				344DD87D1FFEFC910021350B /* URLWithQueryBuilderTests.swift in Sources */,
 				OBJ_27 /* NetworkGetterTests.swift in Sources */,
 				34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */,
+				579F534B200151B700E9996A /* Empty.swift in Sources */,
 				344FC7241FE5C86200958CE4 /* Result+Equatable.swift in Sources */,
 				344FC72F1FE5DA4200958CE4 /* Result+Data.swift in Sources */,
 				3434A0BC1FE7DD74000659E5 /* URLSessionFactoryTests.swift in Sources */,

--- a/Sources/Frisbee/Interactors/URLWithQueryBuilder.swift
+++ b/Sources/Frisbee/Interactors/URLWithQueryBuilder.swift
@@ -3,14 +3,19 @@ import Foundation
 struct URLWithQueryBuilder {
 
     static func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL {
-        let queryItems = try QueryItemBuilder.build(withEntity: query)
-        var urlComponents = URLComponents(string: url)
-        urlComponents?.queryItems = queryItems
+        guard let actualUrl = URL(string: url) else {
+            throw FrisbeeError.invalidUrl
+        }
+        return try build(withUrl: actualUrl, query: query)
+    }
+
+    static func build<Query: Encodable>(withUrl url: URL, query: Query) throws -> URL {
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        urlComponents?.queryItems = try QueryItemBuilder.build(withEntity: query)
 
         guard let url = urlComponents?.url else {
             throw FrisbeeError.invalidUrl
         }
         return url
     }
-
 }

--- a/Sources/Frisbee/Requestables/Getable.swift
+++ b/Sources/Frisbee/Requestables/Getable.swift
@@ -2,6 +2,9 @@ import Foundation
 
 public protocol Getable {
     func get<Entity: Decodable>(url: String, onComplete: @escaping (Result<Entity>) -> Void)
+    func get<Entity: Decodable>(url: URL, onComplete: @escaping (Result<Entity>) -> Void)
     func get<Entity: Decodable, Query: Encodable>(url: String, query: Query,
+                                                  onComplete: @escaping (Result<Entity>) -> Void)
+    func get<Entity: Decodable, Query: Encodable>(url: URL, query: Query,
                                                   onComplete: @escaping (Result<Entity>) -> Void)
 }

--- a/Sources/Frisbee/Requestables/NetworkGetter.swift
+++ b/Sources/Frisbee/Requestables/NetworkGetter.swift
@@ -19,7 +19,19 @@ public class NetworkGetter: Getable {
         makeRequest(url: url, onComplete: onComplete)
     }
 
+    public func get<Entity: Decodable>(url: URL, onComplete: @escaping (Result<Entity>) -> Void) {
+        makeRequest(url: url, onComplete: onComplete)
+    }
+
     public func get<Entity: Decodable, Query: Encodable>(url: String, query: Query,
+                                                         onComplete: @escaping (Result<Entity>) -> Void) {
+        guard let url = URL(string: url) else {
+            return onComplete(.fail(FrisbeeError.invalidUrl))
+        }
+        get(url: url, query: query, onComplete: onComplete)
+    }
+
+    public func get<Entity: Decodable, Query: Encodable>(url: URL, query: Query,
                                                          onComplete: @escaping (Result<Entity>) -> Void) {
         do {
             let url = try URLWithQueryBuilder.build(withUrl: url, query: query)

--- a/Sources/Frisbee/Requestables/NetworkGetter.swift
+++ b/Sources/Frisbee/Requestables/NetworkGetter.swift
@@ -52,7 +52,6 @@ public class NetworkGetter: Getable {
         }
 
         task.resume()
-        urlSession.finishTasksAndInvalidate()
     }
 
 }

--- a/Tests/FrisbeeTests/Helpers/Empty.swift
+++ b/Tests/FrisbeeTests/Helpers/Empty.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Empty: Codable, Equatable {
+    static let data: Data = "{}".data(using: .utf8)!
+
+    static func == (lhs: Empty, rhs: Empty) -> Bool {
+        return true
+    }
+}

--- a/Tests/FrisbeeTests/Helpers/MockURLSession.swift
+++ b/Tests/FrisbeeTests/Helpers/MockURLSession.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+typealias URLSessionCallback = (Data?, URLResponse?, Error?) -> Void
+
+enum MockError: Error {
+    case noMockAvailable
+}
+
+class MockURLSession: URLSession {
+    // not thread safe, make sure tests do not call this on background
+    // or implement a locking mechanism
+    var results: [MockDataTask.Result]
+
+    init(results: [MockDataTask.Result] = []) {
+        self.results = results
+        super.init()
+    }
+
+    override func dataTask(with request: URLRequest,
+                           completionHandler: @escaping URLSessionCallback) -> URLSessionDataTask {
+        guard !results.isEmpty else {
+            return MockDataTask(result: .error(MockError.noMockAvailable),
+                                callback: completionHandler)
+        }
+
+        let result = results.removeFirst()
+        return MockDataTask(result: result, callback: completionHandler)
+    }
+}
+
+class MockDataTask: URLSessionDataTask {
+    enum Result {
+        case success(Data, URLResponse), error(Error)
+    }
+
+    let result: Result
+    let callback: (Data?, URLResponse?, Error?) -> Void
+
+    init(result: Result, callback: @escaping URLSessionCallback) {
+        self.result = result
+        self.callback = callback
+        super.init()
+    }
+
+    override func resume() {
+        switch result {
+        case let .success(data, response):
+            callback(data, response, nil)
+        case let .error(error):
+            callback(nil, nil, error)
+        }
+    }
+}

--- a/Tests/FrisbeeTests/Helpers/SomeError.swift
+++ b/Tests/FrisbeeTests/Helpers/SomeError.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum SomeError: String, Error {
+    case some
+    case another
+}

--- a/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
+++ b/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
@@ -47,11 +47,55 @@ final class IntegrationNetworkGetTests: XCTestCase {
         }
     }
 
+    func testGetURLWhenHasValidURLWithValidEntityThenRequestAndTransformData() {
+        let expectation = self.expectation(description: "RequestMoviesWithSuccess")
+        let expectedMovieName = "Ghostbusters"
+        var returnedData: Movie?
+
+        guard let url = URL(string: self.url) else {
+            return XCTFail("Could not create URL")
+        }
+
+        NetworkGetter().get(url: url) { (result: Result<Movie>) in
+            returnedData = result.data
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 20) { expectationError in
+            XCTAssertNil(expectationError, expectationError!.localizedDescription)
+            XCTAssertEqual(returnedData?.name, expectedMovieName)
+        }
+    }
+
+    func testGetURLWhenHasQueryParametersAndValidURLWithValidEntityThenRequestAndTransformData() {
+        let expectation = self.expectation(description: "RequestMoviesWithSuccess")
+        let expectedMovieName = "Ghostbusters"
+        var returnedData: Movie?
+        let query = MovieQuery(page: 10)
+
+        guard let url = URL(string: self.url) else {
+            return XCTFail("Could not create URL")
+        }
+
+        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
+            returnedData = result.data
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 20) { expectationError in
+            XCTAssertNil(expectationError, expectationError!.localizedDescription)
+            XCTAssertEqual(returnedData?.name, expectedMovieName)
+        }
+    }
+
     static var allTests = [
         ("testGetWhenHasValidURLWithValidEntityThenRequestAndTransformData",
          testGetWhenHasValidURLWithValidEntityThenRequestAndTransformData),
         ("testGetWhenHasQueryParamentersAndValidURLWithValidEntityThenRequestAndTransformData",
-         testGetWhenHasQueryParamentersAndValidURLWithValidEntityThenRequestAndTransformData)
+         testGetWhenHasQueryParamentersAndValidURLWithValidEntityThenRequestAndTransformData),
+        ("testGetURLWhenHasValidURLWithValidEntityThenRequestAndTransformData",
+         testGetURLWhenHasValidURLWithValidEntityThenRequestAndTransformData),
+        ("testGetURLWhenHasQueryParametersAndValidURLWithValidEntityThenRequestAndTransformData",
+         testGetURLWhenHasQueryParametersAndValidURLWithValidEntityThenRequestAndTransformData)
     ]
-
 }

--- a/Tests/FrisbeeTests/Interactors/URLWithQueryBuilderTests.swift
+++ b/Tests/FrisbeeTests/Interactors/URLWithQueryBuilderTests.swift
@@ -16,6 +16,20 @@ class URLWithQueryBuilderTests: XCTestCase {
 
     func testBuildURLWhenHasCorrectQueryWithNilValueThenGenerateURLWithQueryStrings() {
         let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: nil)
+        guard let url = URL(string: "http://www.com.br") else {
+            return XCTFail("Invalid URL")
+        }
+
+        let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
+
+        XCTAssertTrue(builtUrl?.absoluteString.starts(with: url.absoluteString) ?? false)
+        XCTAssertEqual("\(query.page)", getQueryValue(builtUrl?.absoluteString, "page"))
+        XCTAssertEqual("\(query.keyAccess)", getQueryValue(builtUrl?.absoluteString, "key_access"))
+        XCTAssertNil(getQueryValue(builtUrl?.absoluteString, "optional_int"))
+    }
+
+    func testBuildStringURLWhenHasCorrectQueryWithNilValueThenGenerateURLWithQueryStrings() {
+        let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: nil)
         let url = "http://www.com.br"
 
         let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
@@ -28,6 +42,20 @@ class URLWithQueryBuilderTests: XCTestCase {
 
     func testBuildURLWhenHasCorrectQueryWithoutNilValueThenGenerateURLWithQueryStrings() {
         let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: 10)
+        guard let url = URL(string: "http://www.com.br") else {
+            return XCTFail("Invalid URL")
+        }
+
+        let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
+
+        XCTAssertTrue(builtUrl?.absoluteString.starts(with: url.absoluteString) ?? false)
+        XCTAssertEqual("\(query.page)", getQueryValue(builtUrl?.absoluteString, "page"))
+        XCTAssertEqual("\(query.keyAccess)", getQueryValue(builtUrl?.absoluteString, "key_access"))
+        XCTAssertEqual("\(query.optionalInt ?? 0)", getQueryValue(builtUrl?.absoluteString, "optional_int"))
+    }
+
+    func testBuildStringURLWhenHasCorrectQueryWithoutNilValueThenGenerateURLWithQueryStrings() {
+        let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: 10)
         let url = "http://www.com.br"
 
         let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
@@ -38,11 +66,13 @@ class URLWithQueryBuilderTests: XCTestCase {
         XCTAssertEqual("\(query.optionalInt ?? 0)", getQueryValue(builtUrl?.absoluteString, "optional_int"))
     }
 
-    func testBuildURLWhenHasInvalidUrlThenThrowInvalidURLError() {
+    func testBuildStringURLWhenHasInvalidUrlThenThrowInvalidURLError() {
         let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: 10)
         let url = "http://www.çøµ.∫®"
 
-        XCTAssertThrowsError(try URLWithQueryBuilder.build(withUrl: url, query: query))
+        XCTAssertThrowsError(try URLWithQueryBuilder.build(withUrl: url, query: query)) {
+            XCTAssertEqual($0 as? FrisbeeError, FrisbeeError.invalidUrl)
+        }
     }
 
     private func getQueryValue(_ urlString: String?, _ param: String) -> String? {
@@ -53,10 +83,14 @@ class URLWithQueryBuilderTests: XCTestCase {
     static var allTests = [
         ("testBuildURLWhenHasCorrectQueryWithNilValueThenGenerateURLWithQueryStrings",
          testBuildURLWhenHasCorrectQueryWithNilValueThenGenerateURLWithQueryStrings),
+        ("testBuildStringURLWhenHasCorrectQueryWithNilValueThenGenerateURLWithQueryStrings",
+         testBuildStringURLWhenHasCorrectQueryWithNilValueThenGenerateURLWithQueryStrings),
         ("testBuildURLWhenHasCorrectQueryWithoutNilValueThenGenerateURLWithQueryStrings",
          testBuildURLWhenHasCorrectQueryWithoutNilValueThenGenerateURLWithQueryStrings),
-        ("testBuildURLWhenHasInvalidUrlThenThrowInvalidURLError",
-         testBuildURLWhenHasInvalidUrlThenThrowInvalidURLError)
+        ("testBuildStringURLWhenHasCorrectQueryWithoutNilValueThenGenerateURLWithQueryStrings",
+         testBuildStringURLWhenHasCorrectQueryWithoutNilValueThenGenerateURLWithQueryStrings),
+        ("testBuildStringURLWhenHasInvalidUrlThenThrowInvalidURLError",
+         testBuildStringURLWhenHasInvalidUrlThenThrowInvalidURLError)
     ]
 
 }

--- a/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
+++ b/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
@@ -3,12 +3,11 @@ import XCTest
 
 final class NetworkGetterTests: XCTestCase {
 
-    private let invalidUrl = "🤷‍♂️"
-    private let validUrl = "http://www.com.br"
+    private let invalidUrlString = "🤷‍♂️"
+    private let validUrlString = "http://www.com.br"
 
     func testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession() {
         let urlSession = URLSession(configuration: .default)
-
         let networkGetter = NetworkGetter(urlSession: urlSession)
 
         XCTAssertEqual(urlSession, networkGetter.urlSession)
@@ -17,16 +16,81 @@ final class NetworkGetterTests: XCTestCase {
     func testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError() {
         var generatedResult: Result<Data?>!
 
-        NetworkGetter().get(url: invalidUrl) { generatedResult = $0 }
+        NetworkGetter().get(url: invalidUrlString) { generatedResult = $0 }
 
         XCTAssertEqual(generatedResult, Result.fail(FrisbeeError.invalidUrl))
+    }
+
+    func testGetWithValidURL() {
+        let session = MockURLSession(results: [.success(Empty.data, URLResponse())])
+        let getter = NetworkGetter(urlSession: session)
+
+        getter.get(url: validUrlString) { (result: Result<Empty>) in
+            switch result {
+            case let .success(entity):
+                XCTAssertEqual(entity, Empty())
+            default:
+                XCTFail("Expected to succeed")
+            }
+        }
+    }
+
+    func testGetWithInvalidURL() {
+        let session = MockURLSession(results: [])
+        let getter = NetworkGetter(urlSession: session)
+
+        getter.get(url: invalidUrlString) { (result: Result<Empty>) in
+            switch result {
+            case let .fail(error):
+                XCTAssertEqual(error, FrisbeeError.invalidUrl)
+            default:
+                XCTFail("Expected to fail")
+            }
+        }
+    }
+
+    func testGetWithQueryWithInvalidURL() {
+        let session = MockURLSession(results: [])
+        let getter = NetworkGetter(urlSession: session)
+        let query = Empty()
+
+        getter.get(url: invalidUrlString, query: query) { (result: Result<Empty>) in
+            switch result {
+            case let .fail(error):
+                XCTAssertEqual(error, FrisbeeError.invalidUrl)
+            default:
+                XCTFail("Expected to fail")
+            }
+        }
+    }
+
+    func testGetWithValidURLFails() {
+        let session = MockURLSession(results: [.error(SomeError.some)])
+        let getter = NetworkGetter(urlSession: session)
+
+        getter.get(url: validUrlString) { (result: Result<Empty>) in
+            switch result {
+            case let .fail(error):
+                XCTAssertEqual(error, FrisbeeError.other(localizedDescription: SomeError.some.localizedDescription))
+            default:
+                XCTFail("Expected to fail")
+            }
+        }
     }
 
     static var allTests = [
         ("testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError",
          testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError),
         ("testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession",
-         testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession)
+         testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession),
+        ("testGetWithValidURL",
+         testGetWithValidURL),
+        ("testGetWithInvalidURL",
+         testGetWithInvalidURL),
+        ("testGetWithQueryWithInvalidURL",
+         testGetWithQueryWithInvalidURL),
+        ("testGetWithValidURLFails",
+         testGetWithValidURLFails)
     ]
 
 }


### PR DESCRIPTION
This allows `URL` to be build beforehand by someone else
  
The `String` argument overloads should prefer/use `URL` overloads since they are already converted and ready for use