### PR TITLE
Minor fixes at tests

### DIFF
--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		344FC7201FE5BBFE00958CE4 /* NetworkGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */; };
 		344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */; };
 		344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */; };
+		34F91DA32008219600FFAE20 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA12008217500FFAE20 /* Movie.swift */; };
+		34F91DA6200821B900FFAE20 /* XCTestCase+AssertContains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */; };
 		34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */; };
 		34F91DAE2008246700FFAE20 /* MovieQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DAD2008246700FFAE20 /* MovieQuery.swift */; };
 		34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */; };
@@ -82,6 +84,8 @@
 		344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGetter.swift; sourceTree = "<group>"; };
 		344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGenerator.swift; sourceTree = "<group>"; };
 		344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorTests.swift; sourceTree = "<group>"; };
+		34F91DA12008217500FFAE20 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
+		34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AssertContains.swift"; sourceTree = "<group>"; };
 		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
 		34F91DAD2008246700FFAE20 /* MovieQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieQuery.swift; sourceTree = "<group>"; };
 		34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilderTests.swift; sourceTree = "<group>"; };
@@ -150,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				578D2CA620019C3D00EE3865 /* SequenceExtensions.swift */,
+				34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */,
 				34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */,
 			);
 			name = Extensions;
@@ -224,6 +229,8 @@
 				579F5349200151B300E9996A /* Empty.swift */,
 				579F534C200151D700E9996A /* MockURLSession.swift */,
 				579F534F2001521300E9996A /* SomeError.swift */,
+				34F91DA12008217500FFAE20 /* Movie.swift */,
+				34F91DAB200823FA00FFAE20 /* SomeEntity.swift */,
 				34F91DAD2008246700FFAE20 /* MovieQuery.swift */,
 			);
 			path = Helpers;
@@ -415,6 +422,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				34F91DA32008219600FFAE20 /* Movie.swift in Sources */,
 				578D2CA520019B1400EE3865 /* ResultTests.swift in Sources */,
 				579F534E200151DF00E9996A /* MockURLSession.swift in Sources */,
 				578D2CA720019C3D00EE3865 /* SequenceExtensions.swift in Sources */,
@@ -426,6 +434,7 @@
 				OBJ_27 /* NetworkGetterTests.swift in Sources */,
 				34F91DAE2008246700FFAE20 /* MovieQuery.swift in Sources */,
 				34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */,
+				34F91DA6200821B900FFAE20 /* XCTestCase+AssertContains.swift in Sources */,
 				579F534B200151B700E9996A /* Empty.swift in Sources */,
 				3434A0BC1FE7DD74000659E5 /* URLSessionFactoryTests.swift in Sources */,
 				578D2CA3200199A500EE3865 /* FrisbeeErrorTests.swift in Sources */,

--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		344FC7201FE5BBFE00958CE4 /* NetworkGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */; };
 		344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */; };
 		344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */; };
+		34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */; };
 		34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */; };
 		34F9C72C1FE89F44002C1EB0 /* QueryItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */; };
 		578D2CA3200199A500EE3865 /* FrisbeeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578D2CA2200199A500EE3865 /* FrisbeeErrorTests.swift */; };
@@ -80,6 +81,7 @@
 		344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGetter.swift; sourceTree = "<group>"; };
 		344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGenerator.swift; sourceTree = "<group>"; };
 		344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorTests.swift; sourceTree = "<group>"; };
+		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
 		34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilderTests.swift; sourceTree = "<group>"; };
 		34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilder.swift; sourceTree = "<group>"; };
 		578D2CA2200199A500EE3865 /* FrisbeeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrisbeeErrorTests.swift; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 			isa = PBXGroup;
 			children = (
 				578D2CA620019C3D00EE3865 /* SequenceExtensions.swift */,
+				34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */,
 			);
 			name = Extensions;
 			path = Tests/FrisbeeTests/Extensions;
@@ -422,6 +425,7 @@
 				579F534B200151B700E9996A /* Empty.swift in Sources */,
 				3434A0BC1FE7DD74000659E5 /* URLSessionFactoryTests.swift in Sources */,
 				578D2CA3200199A500EE3865 /* FrisbeeErrorTests.swift in Sources */,
+				34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		34F91DA32008219600FFAE20 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA12008217500FFAE20 /* Movie.swift */; };
 		34F91DA6200821B900FFAE20 /* XCTestCase+AssertContains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */; };
 		34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */; };
+		34F91DAC200823FA00FFAE20 /* SomeEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DAB200823FA00FFAE20 /* SomeEntity.swift */; };
 		34F91DAE2008246700FFAE20 /* MovieQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DAD2008246700FFAE20 /* MovieQuery.swift */; };
 		34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */; };
 		34F9C72C1FE89F44002C1EB0 /* QueryItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */; };
@@ -87,6 +88,7 @@
 		34F91DA12008217500FFAE20 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
 		34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AssertContains.swift"; sourceTree = "<group>"; };
 		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
+		34F91DAB200823FA00FFAE20 /* SomeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeEntity.swift; sourceTree = "<group>"; };
 		34F91DAD2008246700FFAE20 /* MovieQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieQuery.swift; sourceTree = "<group>"; };
 		34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilderTests.swift; sourceTree = "<group>"; };
 		34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilder.swift; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 				578D2CA520019B1400EE3865 /* ResultTests.swift in Sources */,
 				579F534E200151DF00E9996A /* MockURLSession.swift in Sources */,
 				578D2CA720019C3D00EE3865 /* SequenceExtensions.swift in Sources */,
+				34F91DAC200823FA00FFAE20 /* SomeEntity.swift in Sources */,
 				3434A0BF1FE7E025000659E5 /* IntegrationNetworkGetTests.swift in Sources */,
 				3434A0BA1FE7DC30000659E5 /* URLRequestFactoryTests.swift in Sources */,
 				579F53512001525100E9996A /* SomeError.swift in Sources */,

--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		34F91DA12008217500FFAE20 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
 		34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AssertContains.swift"; sourceTree = "<group>"; };
 		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
+		34F91DAA2008239600FFAE20 /* LinuxMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LinuxMain.swift; path = Tests/LinuxMain.swift; sourceTree = "<group>"; };
 		34F91DAB200823FA00FFAE20 /* SomeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeEntity.swift; sourceTree = "<group>"; };
 		34F91DAD2008246700FFAE20 /* MovieQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieQuery.swift; sourceTree = "<group>"; };
 		34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilderTests.swift; sourceTree = "<group>"; };
@@ -241,6 +242,7 @@
 		OBJ_10 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				34F91DAA2008239600FFAE20 /* LinuxMain.swift */,
 				OBJ_11 /* FrisbeeTests */,
 			);
 			name = Tests;

--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */; };
 		344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */; };
 		34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */; };
+		34F91DAE2008246700FFAE20 /* MovieQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DAD2008246700FFAE20 /* MovieQuery.swift */; };
 		34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */; };
 		34F9C72C1FE89F44002C1EB0 /* QueryItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */; };
 		578D2CA3200199A500EE3865 /* FrisbeeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578D2CA2200199A500EE3865 /* FrisbeeErrorTests.swift */; };
@@ -82,6 +83,7 @@
 		344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGenerator.swift; sourceTree = "<group>"; };
 		344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorTests.swift; sourceTree = "<group>"; };
 		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
+		34F91DAD2008246700FFAE20 /* MovieQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieQuery.swift; sourceTree = "<group>"; };
 		34F9C7291FE89EF5002C1EB0 /* QueryItemBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilderTests.swift; sourceTree = "<group>"; };
 		34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryItemBuilder.swift; sourceTree = "<group>"; };
 		578D2CA2200199A500EE3865 /* FrisbeeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrisbeeErrorTests.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				579F5349200151B300E9996A /* Empty.swift */,
 				579F534C200151D700E9996A /* MockURLSession.swift */,
 				579F534F2001521300E9996A /* SomeError.swift */,
+				34F91DAD2008246700FFAE20 /* MovieQuery.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */,
 				344DD87D1FFEFC910021350B /* URLWithQueryBuilderTests.swift in Sources */,
 				OBJ_27 /* NetworkGetterTests.swift in Sources */,
+				34F91DAE2008246700FFAE20 /* MovieQuery.swift in Sources */,
 				34F9C72A1FE89EF5002C1EB0 /* QueryItemBuilderTests.swift in Sources */,
 				579F534B200151B700E9996A /* Empty.swift in Sources */,
 				3434A0BC1FE7DD74000659E5 /* URLSessionFactoryTests.swift in Sources */,

--- a/Sources/Frisbee/Requestables/NetworkGetter.swift
+++ b/Sources/Frisbee/Requestables/NetworkGetter.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-@available(*, deprecated, message: "use NetworkGet")
-typealias NetworkGetter = NetworkGet
-
-public class NetworkGet: Getable {
+public class NetworkGetter: Getable {
 
     let urlSession: URLSession
 

--- a/Sources/Frisbee/Requestables/NetworkGetter.swift
+++ b/Sources/Frisbee/Requestables/NetworkGetter.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-public class NetworkGetter: Getable {
+@available(*, deprecated, message: "use NetworkGet")
+typealias NetworkGetter = NetworkGet
+
+public class NetworkGet: Getable {
 
     let urlSession: URLSession
 

--- a/Tests/FrisbeeTests/Entities/FrisbeeErrorTests.swift
+++ b/Tests/FrisbeeTests/Entities/FrisbeeErrorTests.swift
@@ -3,17 +3,18 @@ import Frisbee
 import XCTest
 
 class FrisbeeErrorTests: XCTestCase {
-    func testEquality() {
+
+    func testEquatableFromAllPossibleErrorsThenBeEqual() {
         let all = FrisbeeError.all(error: SomeError.some)
 
-        // asserts diagonal equality
         zip(all, all).forEach { lhs, rhs in
             XCTAssertEqual(lhs, rhs)
         }
     }
 
-    func testInequality() {
+    func testInequatableFromAllPossibleErrorsThenBeNotEqual() {
         let all = FrisbeeError.all(error: SomeError.some).enumerated()
+
         all.extensiveCombine(all).forEach { lhs, rhs in
             if lhs.offset == rhs.offset { //diagonal cases
                 XCTAssertEqual(lhs.element, rhs.element)
@@ -22,12 +23,12 @@ class FrisbeeErrorTests: XCTestCase {
             }
         }
     }
-}
 
-extension FrisbeeError {
-    static func all(error: Error) -> [FrisbeeError] {
-        return [FrisbeeError.invalidUrl, .invalidQuery,
-                .invalidEntity, .noData, .unknown,
-                .other(localizedDescription: error.localizedDescription)]
-    }
+    static var allTests = [
+        ("testEquatableFromAllPossibleErrorsThenBeEqual",
+         testEquatableFromAllPossibleErrorsThenBeEqual),
+        ("testInequatableFromAllPossibleErrorsThenBeNotEqual",
+         testInequatableFromAllPossibleErrorsThenBeNotEqual)
+    ]
+
 }

--- a/Tests/FrisbeeTests/Entities/ResultTests.swift
+++ b/Tests/FrisbeeTests/Entities/ResultTests.swift
@@ -3,15 +3,8 @@ import Frisbee
 import XCTest
 
 class ResultTests: XCTestCase {
-    private struct SomeEntity {}
-    private struct SomeEquatableEntity: Equatable {
-        static func == (lhs: SomeEquatableEntity,
-                        rhs: SomeEquatableEntity) -> Bool {
-            return true
-        }
-    }
 
-    func testProperties() {
+    func testEquatableEnumCasesWhenAssociatedValueAreEquatableThenShouldBeEqual() {
         let success = Result.success(SomeEquatableEntity())
         let fail = Result<SomeEquatableEntity>.fail(FrisbeeError.invalidEntity)
 
@@ -24,7 +17,7 @@ class ResultTests: XCTestCase {
         XCTAssertNil(fail.data)
     }
 
-    func testEquality() {
+    func testEquatableEnumCasesWhenAssociatedValueArentEquatableThenShoudBeNotEqual() {
         let success = Result.success(SomeEntity())
         let fail = Result<SomeEntity>.fail(FrisbeeError.invalidEntity)
 
@@ -34,7 +27,7 @@ class ResultTests: XCTestCase {
         XCTAssertEqual(fail, fail)
     }
 
-    func testEqualityOperatorWithEquatableEntity() {
+    func testEqualityOperatorWhenEquatableEntityThenShoudeBeEqual() {
         let success = Result.success(SomeEquatableEntity())
         let fail = Result<SomeEquatableEntity>.fail(FrisbeeError.invalidEntity)
 
@@ -43,4 +36,14 @@ class ResultTests: XCTestCase {
         XCTAssertFalse(success == fail)
         XCTAssertFalse(fail == success)
     }
+
+    static var allTests = [
+        ("testEquatableEnumCasesWhenAssociatedValueAreEquatableThenShouldBeEqual",
+         testEquatableEnumCasesWhenAssociatedValueAreEquatableThenShouldBeEqual),
+        ("testEquatableEnumCasesWhenAssociatedValueArentEquatableThenShoudBeNotEqual",
+         testEquatableEnumCasesWhenAssociatedValueArentEquatableThenShoudBeNotEqual),
+        ("testEqualityOperatorWhenEquatableEntityThenShoudeBeEqual",
+         testEqualityOperatorWhenEquatableEntityThenShoudeBeEqual)
+    ]
+
 }

--- a/Tests/FrisbeeTests/Extensions/FrisbeeError+All.swift
+++ b/Tests/FrisbeeTests/Extensions/FrisbeeError+All.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Frisbee
+
+extension FrisbeeError {
+    static func all(error: Error) -> [FrisbeeError] {
+        return [FrisbeeError.invalidUrl, .invalidQuery,
+                .invalidEntity, .noData, .unknown,
+                .other(localizedDescription: error.localizedDescription)]
+    }
+}

--- a/Tests/FrisbeeTests/Extensions/XCTestCase+AssertContains.swift
+++ b/Tests/FrisbeeTests/Extensions/XCTestCase+AssertContains.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+extension XCTestCase {
+    func XCTAssertContains<T>(_ array: [T], _ predicate: (T) -> Bool, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(array.contains(where: predicate))
+    }
+}

--- a/Tests/FrisbeeTests/Factories/URLRequestFactoryTests.swift
+++ b/Tests/FrisbeeTests/Factories/URLRequestFactoryTests.swift
@@ -3,10 +3,6 @@ import XCTest
 
 final class URLRequestFactoryTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-    }
-
     func testMakeWhenGetMethodThenReturnAnURLRequestWithGetVerb() {
         let request = URLRequestFactory.make(.GET, URL(string: "http://www.com.br")!)
 

--- a/Tests/FrisbeeTests/Helpers/Movie.swift
+++ b/Tests/FrisbeeTests/Helpers/Movie.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Movie: Encodable {
+    let name: String
+    let releaseYear: Int
+
+    enum CodingKeys: String, CodingKey {
+        case name, releaseYear = "release_year"
+    }
+}

--- a/Tests/FrisbeeTests/Helpers/MovieQuery.swift
+++ b/Tests/FrisbeeTests/Helpers/MovieQuery.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct MovieQuery: Encodable {
+    let page: Int
+}

--- a/Tests/FrisbeeTests/Helpers/SomeEntity.swift
+++ b/Tests/FrisbeeTests/Helpers/SomeEntity.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct SomeEntity {}
+struct SomeEquatableEntity: Equatable {
+    static func == (lhs: SomeEquatableEntity,
+                    rhs: SomeEquatableEntity) -> Bool {
+        return true
+    }
+}

--- a/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
+++ b/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
@@ -10,10 +10,6 @@ final class IntegrationNetworkGetTests: XCTestCase {
         let name: String
     }
 
-    struct MovieQuery: Encodable {
-        let page: Int
-    }
-
     func testGetWhenHasValidURLWithValidEntityThenRequestAndTransformData() {
         let longRunningExpectation = expectation(description: "RequestMoviesWithSuccess")
         let expectedMovieName = "Ghostbusters"

--- a/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
+++ b/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
@@ -15,7 +15,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
         let expectedMovieName = "Ghostbusters"
         var returnedData: Movie?
 
-        NetworkGet().get(url: url) { (result: Result<Movie>) in
+        NetworkGetter().get(url: url) { (result: Result<Movie>) in
             returnedData = result.data
             longRunningExpectation.fulfill()
         }
@@ -32,7 +32,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
         var returnedData: Movie?
         let query = MovieQuery(page: 10)
 
-        NetworkGet().get(url: url, query: query) { (result: Result<Movie>) in
+        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
             returnedData = result.data
             longRunningExpectation.fulfill()
         }
@@ -52,7 +52,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
             return XCTFail("Could not create URL")
         }
 
-        NetworkGet().get(url: url) { (result: Result<Movie>) in
+        NetworkGetter().get(url: url) { (result: Result<Movie>) in
             returnedData = result.data
             expectation.fulfill()
         }
@@ -73,7 +73,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
             return XCTFail("Could not create URL")
         }
 
-        NetworkGet().get(url: url, query: query) { (result: Result<Movie>) in
+        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
             returnedData = result.data
             expectation.fulfill()
         }

--- a/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
+++ b/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
@@ -19,7 +19,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
         let expectedMovieName = "Ghostbusters"
         var returnedData: Movie?
 
-        NetworkGetter().get(url: url) { (result: Result<Movie>) in
+        NetworkGet().get(url: url) { (result: Result<Movie>) in
             returnedData = result.data
             longRunningExpectation.fulfill()
         }
@@ -36,7 +36,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
         var returnedData: Movie?
         let query = MovieQuery(page: 10)
 
-        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
+        NetworkGet().get(url: url, query: query) { (result: Result<Movie>) in
             returnedData = result.data
             longRunningExpectation.fulfill()
         }
@@ -56,7 +56,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
             return XCTFail("Could not create URL")
         }
 
-        NetworkGetter().get(url: url) { (result: Result<Movie>) in
+        NetworkGet().get(url: url) { (result: Result<Movie>) in
             returnedData = result.data
             expectation.fulfill()
         }
@@ -77,7 +77,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
             return XCTFail("Could not create URL")
         }
 
-        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
+        NetworkGet().get(url: url, query: query) { (result: Result<Movie>) in
             returnedData = result.data
             expectation.fulfill()
         }

--- a/Tests/FrisbeeTests/Interactors/QueryItemBuilderTests.swift
+++ b/Tests/FrisbeeTests/Interactors/QueryItemBuilderTests.swift
@@ -1,15 +1,6 @@
 import XCTest
 @testable import Frisbee
 
-private struct Movie: Encodable {
-    let name: String
-    let releaseYear: Int
-
-    enum CodingKeys: String, CodingKey {
-        case name, releaseYear = "release_year"
-    }
-}
-
 final class QueryItemBuilderTests: XCTestCase {
 
     func testBuildWhenValidDictionaryThenReturnQueryItem() throws {
@@ -29,10 +20,4 @@ final class QueryItemBuilderTests: XCTestCase {
          testBuildWhenValidDictionaryThenReturnQueryItem)
     ]
 
-}
-
-extension XCTestCase {
-    func XCTAssertContains<T>(_ array: [T], _ predicate: (T) -> Bool, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertTrue(array.contains(where: predicate))
-    }
 }

--- a/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
+++ b/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
@@ -8,7 +8,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession() {
         let urlSession = URLSession(configuration: .default)
-        let networkGetter = NetworkGetter(urlSession: urlSession)
+        let networkGetter = NetworkGet(urlSession: urlSession)
 
         XCTAssertEqual(urlSession, networkGetter.urlSession)
     }
@@ -16,14 +16,14 @@ final class NetworkGetterTests: XCTestCase {
     func testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError() {
         var generatedResult: Result<Data?>!
 
-        NetworkGetter().get(url: invalidUrlString) { generatedResult = $0 }
+        NetworkGet().get(url: invalidUrlString) { generatedResult = $0 }
 
         XCTAssertEqual(generatedResult, Result.fail(FrisbeeError.invalidUrl))
     }
 
     func testGetWithValidURL() {
         let session = MockURLSession(results: [.success(Empty.data, URLResponse())])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
 
         getter.get(url: validUrlString) { (result: Result<Empty>) in
             switch result {
@@ -37,7 +37,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWithInvalidURL() {
         let session = MockURLSession(results: [])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
 
         getter.get(url: invalidUrlString) { (result: Result<Empty>) in
             switch result {
@@ -51,7 +51,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWithQueryWithInvalidURL() {
         let session = MockURLSession(results: [])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
         let query = Empty()
 
         getter.get(url: invalidUrlString, query: query) { (result: Result<Empty>) in
@@ -66,7 +66,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWithValidURLFails() {
         let session = MockURLSession(results: [.error(SomeError.some)])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
 
         getter.get(url: validUrlString) { (result: Result<Empty>) in
             switch result {

--- a/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
+++ b/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
@@ -8,7 +8,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession() {
         let urlSession = URLSession(configuration: .default)
-        let networkGetter = NetworkGet(urlSession: urlSession)
+        let networkGetter = NetworkGetter(urlSession: urlSession)
 
         XCTAssertEqual(urlSession, networkGetter.urlSession)
     }
@@ -16,15 +16,15 @@ final class NetworkGetterTests: XCTestCase {
     func testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError() {
         var generatedResult: Result<Data?>!
 
-        NetworkGet().get(url: invalidUrlString) { generatedResult = $0 }
+        NetworkGetter().get(url: invalidUrlString) { generatedResult = $0 }
 
         XCTAssertEqual(generatedResult, Result.fail(.invalidUrl))
     }
 
     func testGetWhenValidURLThenGenerateSuccessResult() {
         let session = MockURLSession(results: [.success(Empty.data, URLResponse())])
-        let getter = NetworkGet(urlSession: session)
         var generatedResult: Result<Empty>!
+        let getter = NetworkGetter(urlSession: session)
 
         getter.get(url: validUrlString) { generatedResult = $0 }
 
@@ -34,7 +34,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWhenInvalidURLThenGenerateFailResult() {
         let session = MockURLSession(results: [])
-        let getter = NetworkGet(urlSession: session)
+        let getter = NetworkGetter(urlSession: session)
         var generatedResult: Result<Empty>!
 
         getter.get(url: invalidUrlString) { generatedResult = $0 }
@@ -45,7 +45,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWithQueryWhenInvalidURLThenGenerateFailResult() {
         let session = MockURLSession(results: [])
-        let getter = NetworkGet(urlSession: session)
+        let getter = NetworkGetter(urlSession: session)
         let query = Empty()
         var generatedResult: Result<Empty>!
 
@@ -57,7 +57,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWhenValidURLAndRequestFailsThenGenerateFailResult() {
         let session = MockURLSession(results: [.error(SomeError.some)])
-        let getter = NetworkGet(urlSession: session)
+        let getter = NetworkGetter(urlSession: session)
         var generatedResult: Result<Empty>!
 
         getter.get(url: validUrlString) { generatedResult = $0 }

--- a/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
+++ b/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
@@ -18,64 +18,52 @@ final class NetworkGetterTests: XCTestCase {
 
         NetworkGet().get(url: invalidUrlString) { generatedResult = $0 }
 
-        XCTAssertEqual(generatedResult, Result.fail(FrisbeeError.invalidUrl))
+        XCTAssertEqual(generatedResult, Result.fail(.invalidUrl))
     }
 
-    func testGetWithValidURL() {
+    func testGetWhenValidURLThenGenerateSuccessResult() {
         let session = MockURLSession(results: [.success(Empty.data, URLResponse())])
         let getter = NetworkGet(urlSession: session)
+        var generatedResult: Result<Empty>!
 
-        getter.get(url: validUrlString) { (result: Result<Empty>) in
-            switch result {
-            case let .success(entity):
-                XCTAssertEqual(entity, Empty())
-            default:
-                XCTFail("Expected to succeed")
-            }
-        }
+        getter.get(url: validUrlString) { generatedResult = $0 }
+
+        XCTAssertEqual(generatedResult.data, Empty())
+        XCTAssertNil(generatedResult.error)
     }
 
-    func testGetWithInvalidURL() {
+    func testGetWhenInvalidURLThenGenerateFailResult() {
         let session = MockURLSession(results: [])
         let getter = NetworkGet(urlSession: session)
+        var generatedResult: Result<Empty>!
 
-        getter.get(url: invalidUrlString) { (result: Result<Empty>) in
-            switch result {
-            case let .fail(error):
-                XCTAssertEqual(error, FrisbeeError.invalidUrl)
-            default:
-                XCTFail("Expected to fail")
-            }
-        }
+        getter.get(url: invalidUrlString) { generatedResult = $0 }
+
+        XCTAssertEqual(generatedResult.error, .invalidUrl)
+        XCTAssertNil(generatedResult.data)
     }
 
-    func testGetWithQueryWithInvalidURL() {
+    func testGetWithQueryWhenInvalidURLThenGenerateFailResult() {
         let session = MockURLSession(results: [])
         let getter = NetworkGet(urlSession: session)
         let query = Empty()
+        var generatedResult: Result<Empty>!
 
-        getter.get(url: invalidUrlString, query: query) { (result: Result<Empty>) in
-            switch result {
-            case let .fail(error):
-                XCTAssertEqual(error, FrisbeeError.invalidUrl)
-            default:
-                XCTFail("Expected to fail")
-            }
-        }
+        getter.get(url: invalidUrlString, query: query) { generatedResult = $0 }
+
+        XCTAssertEqual(generatedResult.error, .invalidUrl)
+        XCTAssertNil(generatedResult.data)
     }
 
-    func testGetWithValidURLFails() {
+    func testGetWhenValidURLAndRequestFailsThenGenerateFailResult() {
         let session = MockURLSession(results: [.error(SomeError.some)])
         let getter = NetworkGet(urlSession: session)
+        var generatedResult: Result<Empty>!
 
-        getter.get(url: validUrlString) { (result: Result<Empty>) in
-            switch result {
-            case let .fail(error):
-                XCTAssertEqual(error, FrisbeeError.other(localizedDescription: SomeError.some.localizedDescription))
-            default:
-                XCTFail("Expected to fail")
-            }
-        }
+        getter.get(url: validUrlString) { generatedResult = $0 }
+
+        XCTAssertEqual(generatedResult.error, .other(localizedDescription: SomeError.some.localizedDescription))
+        XCTAssertNil(generatedResult.data)
     }
 
     static var allTests = [
@@ -83,14 +71,14 @@ final class NetworkGetterTests: XCTestCase {
          testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError),
         ("testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession",
          testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession),
-        ("testGetWithValidURL",
-         testGetWithValidURL),
-        ("testGetWithInvalidURL",
-         testGetWithInvalidURL),
-        ("testGetWithQueryWithInvalidURL",
-         testGetWithQueryWithInvalidURL),
-        ("testGetWithValidURLFails",
-         testGetWithValidURLFails)
+        ("testGetWhenValidURLThenGenerateSuccessResult",
+         testGetWhenValidURLThenGenerateSuccessResult),
+        ("testGetWhenInvalidURLThenGenerateFailResult",
+         testGetWhenInvalidURLThenGenerateFailResult),
+        ("testGetWithQueryWhenInvalidURLThenGenerateFailResult",
+         testGetWithQueryWhenInvalidURLThenGenerateFailResult),
+        ("testGetWhenValidURLAndRequestFailsThenGenerateFailResult",
+         testGetWhenValidURLAndRequestFailsThenGenerateFailResult)
     ]
 
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,5 +8,7 @@ XCTMain([
     testCase(URLRequestFactoryTests.allTests),
     testCase(QueryItemBuilderTests.allTests),
     testCase(URLWithQueryBuilderTests.allTests),
-    testCase(ResultGeneratorTests.allTests)
+    testCase(ResultGeneratorTests.allTests),
+    testCase(FrisbeeErrorTests.allTests),
+    testCase(ResultTests.allTests)
 ])


### PR DESCRIPTION
- Update `LinuxMain.swift`
- Remove unnecessary `setup` method at `URLRequestFactoryTests`
- Extract test structs to files
- Extract XCTest extension to file
- Rename some tests