### PR TITLE
Rename NetworkGetter to NetworkGet and deprecate NetworkGetter

### DIFF
--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		344FC71A1FE5B93200958CE4 /* Getable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7191FE5B93200958CE4 /* Getable.swift */; };
 		344FC71C1FE5B9D500958CE4 /* FrisbeeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71B1FE5B9D500958CE4 /* FrisbeeError.swift */; };
 		344FC71E1FE5BA0200958CE4 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71D1FE5BA0200958CE4 /* Result.swift */; };
-		344FC7201FE5BBFE00958CE4 /* NetworkGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */; };
+		344FC7201FE5BBFE00958CE4 /* NetworkGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71F1FE5BBFE00958CE4 /* NetworkGet.swift */; };
 		344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */; };
 		344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */; };
 		34F91DA32008219600FFAE20 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA12008217500FFAE20 /* Movie.swift */; };
@@ -82,7 +82,7 @@
 		344FC7191FE5B93200958CE4 /* Getable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getable.swift; sourceTree = "<group>"; };
 		344FC71B1FE5B9D500958CE4 /* FrisbeeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrisbeeError.swift; sourceTree = "<group>"; };
 		344FC71D1FE5BA0200958CE4 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
-		344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGetter.swift; sourceTree = "<group>"; };
+		344FC71F1FE5BBFE00958CE4 /* NetworkGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGet.swift; sourceTree = "<group>"; };
 		344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGenerator.swift; sourceTree = "<group>"; };
 		344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorTests.swift; sourceTree = "<group>"; };
 		34F91DA12008217500FFAE20 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
@@ -168,7 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				344FC7191FE5B93200958CE4 /* Getable.swift */,
-				344FC71F1FE5BBFE00958CE4 /* NetworkGetter.swift */,
+				344FC71F1FE5BBFE00958CE4 /* NetworkGet.swift */,
 			);
 			name = Requestables;
 			path = Sources/Frisbee/Requestables;
@@ -457,7 +457,7 @@
 				344FC71E1FE5BA0200958CE4 /* Result.swift in Sources */,
 				344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */,
 				3434A0B61FE7DA5A000659E5 /* HTTPMethod.swift in Sources */,
-				344FC7201FE5BBFE00958CE4 /* NetworkGetter.swift in Sources */,
+				344FC7201FE5BBFE00958CE4 /* NetworkGet.swift in Sources */,
 				3434A0B21FE7D9CC000659E5 /* URLRequestFactory.swift in Sources */,
 				344FC71C1FE5B9D500958CE4 /* FrisbeeError.swift in Sources */,
 				34F9C72C1FE89F44002C1EB0 /* QueryItemBuilder.swift in Sources */,

--- a/Sources/Frisbee/Requestables/NetworkGet.swift
+++ b/Sources/Frisbee/Requestables/NetworkGet.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-public class NetworkGetter: Getable {
+@available(*, deprecated, message: "use NetworkGet")
+typealias NetworkGetter = NetworkGet
+
+public class NetworkGet: Getable {
 
     let urlSession: URLSession
 

--- a/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
+++ b/Tests/FrisbeeTests/Integration/IntegrationNetworkGetTests.swift
@@ -15,7 +15,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
         let expectedMovieName = "Ghostbusters"
         var returnedData: Movie?
 
-        NetworkGetter().get(url: url) { (result: Result<Movie>) in
+        NetworkGet().get(url: url) { (result: Result<Movie>) in
             returnedData = result.data
             longRunningExpectation.fulfill()
         }
@@ -32,7 +32,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
         var returnedData: Movie?
         let query = MovieQuery(page: 10)
 
-        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
+        NetworkGet().get(url: url, query: query) { (result: Result<Movie>) in
             returnedData = result.data
             longRunningExpectation.fulfill()
         }
@@ -52,7 +52,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
             return XCTFail("Could not create URL")
         }
 
-        NetworkGetter().get(url: url) { (result: Result<Movie>) in
+        NetworkGet().get(url: url) { (result: Result<Movie>) in
             returnedData = result.data
             expectation.fulfill()
         }
@@ -73,7 +73,7 @@ final class IntegrationNetworkGetTests: XCTestCase {
             return XCTFail("Could not create URL")
         }
 
-        NetworkGetter().get(url: url, query: query) { (result: Result<Movie>) in
+        NetworkGet().get(url: url, query: query) { (result: Result<Movie>) in
             returnedData = result.data
             expectation.fulfill()
         }

--- a/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
+++ b/Tests/FrisbeeTests/Requestables/NetworkGetterTests.swift
@@ -8,7 +8,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testInitWithCustomUrlSessionThenKeepSameReferenceOfUrlSession() {
         let urlSession = URLSession(configuration: .default)
-        let networkGetter = NetworkGetter(urlSession: urlSession)
+        let networkGetter = NetworkGet(urlSession: urlSession)
 
         XCTAssertEqual(urlSession, networkGetter.urlSession)
     }
@@ -16,15 +16,15 @@ final class NetworkGetterTests: XCTestCase {
     func testGetWhenURLStringIsInvalidFormatThenExecuteCompletionHandlerWithInvalidURLError() {
         var generatedResult: Result<Data?>!
 
-        NetworkGetter().get(url: invalidUrlString) { generatedResult = $0 }
+        NetworkGet().get(url: invalidUrlString) { generatedResult = $0 }
 
         XCTAssertEqual(generatedResult, Result.fail(.invalidUrl))
     }
 
     func testGetWhenValidURLThenGenerateSuccessResult() {
         let session = MockURLSession(results: [.success(Empty.data, URLResponse())])
+        let getter = NetworkGet(urlSession: session)
         var generatedResult: Result<Empty>!
-        let getter = NetworkGetter(urlSession: session)
 
         getter.get(url: validUrlString) { generatedResult = $0 }
 
@@ -34,7 +34,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWhenInvalidURLThenGenerateFailResult() {
         let session = MockURLSession(results: [])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
         var generatedResult: Result<Empty>!
 
         getter.get(url: invalidUrlString) { generatedResult = $0 }
@@ -45,7 +45,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWithQueryWhenInvalidURLThenGenerateFailResult() {
         let session = MockURLSession(results: [])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
         let query = Empty()
         var generatedResult: Result<Empty>!
 
@@ -57,7 +57,7 @@ final class NetworkGetterTests: XCTestCase {
 
     func testGetWhenValidURLAndRequestFailsThenGenerateFailResult() {
         let session = MockURLSession(results: [.error(SomeError.some)])
-        let getter = NetworkGetter(urlSession: session)
+        let getter = NetworkGet(urlSession: session)
         var generatedResult: Result<Empty>!
 
         getter.get(url: validUrlString) { generatedResult = $0 }


### PR DESCRIPTION
Renamed this because `NetworkPoster` will sounds weird