### PR TITLE
Create init for error receiving an Error + Remove unknown error

### DIFF
--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		344FC7201FE5BBFE00958CE4 /* NetworkGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC71F1FE5BBFE00958CE4 /* NetworkGet.swift */; };
 		344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */; };
 		344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */; };
+		34C52E832009844400DCD88C /* URLWithQueryBuildableFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E802009841200DCD88C /* URLWithQueryBuildableFactory.swift */; };
 		34F91DA32008219600FFAE20 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA12008217500FFAE20 /* Movie.swift */; };
 		34F91DA6200821B900FFAE20 /* XCTestCase+AssertContains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */; };
 		34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */; };
@@ -85,6 +86,7 @@
 		344FC71F1FE5BBFE00958CE4 /* NetworkGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGet.swift; sourceTree = "<group>"; };
 		344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGenerator.swift; sourceTree = "<group>"; };
 		344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorTests.swift; sourceTree = "<group>"; };
+		34C52E802009841200DCD88C /* URLWithQueryBuildableFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLWithQueryBuildableFactory.swift; sourceTree = "<group>"; };
 		34F91DA12008217500FFAE20 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
 		34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AssertContains.swift"; sourceTree = "<group>"; };
 		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			children = (
 				3434A0B01FE7D952000659E5 /* URLRequestFactory.swift */,
 				3434A0B31FE7D9FF000659E5 /* URLSessionFactory.swift */,
+				34C52E802009841200DCD88C /* URLWithQueryBuildableFactory.swift */,
 			);
 			name = Factories;
 			path = Sources/Frisbee/Factories;
@@ -453,6 +456,7 @@
 			files = (
 				344FC71A1FE5B93200958CE4 /* Getable.swift in Sources */,
 				344DD87B1FFEFBE40021350B /* URLWithQueryBuilder.swift in Sources */,
+				34C52E832009844400DCD88C /* URLWithQueryBuildableFactory.swift in Sources */,
 				3434A0B41FE7D9FF000659E5 /* URLSessionFactory.swift in Sources */,
 				344FC71E1FE5BA0200958CE4 /* Result.swift in Sources */,
 				344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */,

--- a/Frisbee.xcodeproj/project.pbxproj
+++ b/Frisbee.xcodeproj/project.pbxproj
@@ -36,6 +36,11 @@
 		344FC7261FE5D76B00958CE4 /* ResultGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */; };
 		344FC7291FE5D7FC00958CE4 /* ResultGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */; };
 		34C52E832009844400DCD88C /* URLWithQueryBuildableFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E802009841200DCD88C /* URLWithQueryBuildableFactory.swift */; };
+		34C52E852009895D00DCD88C /* FrisbeeDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E842009895D00DCD88C /* FrisbeeDecodable.swift */; };
+		34C52E8720098A0F00DCD88C /* ResultGeneratorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E8620098A0F00DCD88C /* ResultGeneratorFactory.swift */; };
+		34C52E8920098A3100DCD88C /* FrisbeeDecodableFacotry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E8820098A3100DCD88C /* FrisbeeDecodableFacotry.swift */; };
+		34C52E8B20098D4100DCD88C /* FrisbeeJSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E8A20098D4100DCD88C /* FrisbeeJSONDecoder.swift */; };
+		34C52E8D20098D8D00DCD88C /* URLWithQueryBuildable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C52E8C20098D8D00DCD88C /* URLWithQueryBuildable.swift */; };
 		34F91DA32008219600FFAE20 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA12008217500FFAE20 /* Movie.swift */; };
 		34F91DA6200821B900FFAE20 /* XCTestCase+AssertContains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */; };
 		34F91DA9200822F500FFAE20 /* FrisbeeError+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */; };
@@ -87,6 +92,11 @@
 		344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGenerator.swift; sourceTree = "<group>"; };
 		344FC7271FE5D7F900958CE4 /* ResultGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorTests.swift; sourceTree = "<group>"; };
 		34C52E802009841200DCD88C /* URLWithQueryBuildableFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLWithQueryBuildableFactory.swift; sourceTree = "<group>"; };
+		34C52E842009895D00DCD88C /* FrisbeeDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrisbeeDecodable.swift; sourceTree = "<group>"; };
+		34C52E8620098A0F00DCD88C /* ResultGeneratorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultGeneratorFactory.swift; sourceTree = "<group>"; };
+		34C52E8820098A3100DCD88C /* FrisbeeDecodableFacotry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrisbeeDecodableFacotry.swift; sourceTree = "<group>"; };
+		34C52E8A20098D4100DCD88C /* FrisbeeJSONDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrisbeeJSONDecoder.swift; sourceTree = "<group>"; };
+		34C52E8C20098D8D00DCD88C /* URLWithQueryBuildable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLWithQueryBuildable.swift; sourceTree = "<group>"; };
 		34F91DA12008217500FFAE20 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
 		34F91DA4200821A500FFAE20 /* XCTestCase+AssertContains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AssertContains.swift"; sourceTree = "<group>"; };
 		34F91DA7200822E000FFAE20 /* FrisbeeError+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FrisbeeError+All.swift"; sourceTree = "<group>"; };
@@ -129,6 +139,8 @@
 		3434A0AF1FE7D912000659E5 /* Factories */ = {
 			isa = PBXGroup;
 			children = (
+				34C52E8820098A3100DCD88C /* FrisbeeDecodableFacotry.swift */,
+				34C52E8620098A0F00DCD88C /* ResultGeneratorFactory.swift */,
 				3434A0B01FE7D952000659E5 /* URLRequestFactory.swift */,
 				3434A0B31FE7D9FF000659E5 /* URLSessionFactory.swift */,
 				34C52E802009841200DCD88C /* URLWithQueryBuildableFactory.swift */,
@@ -180,6 +192,8 @@
 		344FC7311FE5DBAB00958CE4 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				34C52E842009895D00DCD88C /* FrisbeeDecodable.swift */,
+				34C52E8A20098D4100DCD88C /* FrisbeeJSONDecoder.swift */,
 				344FC71B1FE5B9D500958CE4 /* FrisbeeError.swift */,
 				3434A0B51FE7DA5A000659E5 /* HTTPMethod.swift */,
 				344FC71D1FE5BA0200958CE4 /* Result.swift */,
@@ -202,6 +216,7 @@
 			children = (
 				34F9C72B1FE89F44002C1EB0 /* QueryItemBuilder.swift */,
 				344FC7251FE5D76B00958CE4 /* ResultGenerator.swift */,
+				34C52E8C20098D8D00DCD88C /* URLWithQueryBuildable.swift */,
 				344DD8791FFEFB120021350B /* URLWithQueryBuilder.swift */,
 			);
 			name = Interactors;
@@ -454,6 +469,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				34C52E8720098A0F00DCD88C /* ResultGeneratorFactory.swift in Sources */,
 				344FC71A1FE5B93200958CE4 /* Getable.swift in Sources */,
 				344DD87B1FFEFBE40021350B /* URLWithQueryBuilder.swift in Sources */,
 				34C52E832009844400DCD88C /* URLWithQueryBuildableFactory.swift in Sources */,
@@ -463,8 +479,12 @@
 				3434A0B61FE7DA5A000659E5 /* HTTPMethod.swift in Sources */,
 				344FC7201FE5BBFE00958CE4 /* NetworkGet.swift in Sources */,
 				3434A0B21FE7D9CC000659E5 /* URLRequestFactory.swift in Sources */,
+				34C52E852009895D00DCD88C /* FrisbeeDecodable.swift in Sources */,
+				34C52E8920098A3100DCD88C /* FrisbeeDecodableFacotry.swift in Sources */,
+				34C52E8B20098D4100DCD88C /* FrisbeeJSONDecoder.swift in Sources */,
 				344FC71C1FE5B9D500958CE4 /* FrisbeeError.swift in Sources */,
 				34F9C72C1FE89F44002C1EB0 /* QueryItemBuilder.swift in Sources */,
+				34C52E8D20098D8D00DCD88C /* URLWithQueryBuildable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Frisbee/Entities/FrisbeeDecodable.swift
+++ b/Sources/Frisbee/Entities/FrisbeeDecodable.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol FrisbeeDecodable {
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T
+}

--- a/Sources/Frisbee/Entities/FrisbeeError.swift
+++ b/Sources/Frisbee/Entities/FrisbeeError.swift
@@ -4,7 +4,13 @@ public enum FrisbeeError: Error {
     case noData
     case invalidQuery
     case invalidEntity
-    case unknown
+
+    init(_ error: Error) {
+        guard let frisbeeError = error as? FrisbeeError else {
+            self = .other(localizedDescription: error.localizedDescription); return
+        }
+        self = frisbeeError
+    }
 }
 
 extension FrisbeeError: Equatable {
@@ -13,8 +19,7 @@ extension FrisbeeError: Equatable {
         case (.invalidUrl, .invalidUrl),
              (.noData, .noData),
              (.invalidQuery, .invalidQuery),
-             (.invalidEntity, .invalidEntity),
-             (.unknown, .unknown):
+             (.invalidEntity, .invalidEntity):
             return true
         case let (.other(lhs), .other(rhs)):
             return lhs == rhs

--- a/Sources/Frisbee/Entities/FrisbeeJSONDecoder.swift
+++ b/Sources/Frisbee/Entities/FrisbeeJSONDecoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class FrisbeeJSONDecoder: FrisbeeDecodable {
+
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+}

--- a/Sources/Frisbee/Factories/FrisbeeDecodableFacotry.swift
+++ b/Sources/Frisbee/Factories/FrisbeeDecodableFacotry.swift
@@ -1,0 +1,7 @@
+struct FrisbeeDecodableFacotry {
+
+    static func make() -> FrisbeeDecodable {
+        return FrisbeeJSONDecoder()
+    }
+
+}

--- a/Sources/Frisbee/Factories/ResultGeneratorFactory.swift
+++ b/Sources/Frisbee/Factories/ResultGeneratorFactory.swift
@@ -1,0 +1,7 @@
+struct ResultGeneratorFactory {
+
+    static func make<Entity: Decodable>() -> ResultGenerator<Entity> {
+        return ResultGenerator(decoder: FrisbeeDecodableFacotry.make())
+    }
+
+}

--- a/Sources/Frisbee/Factories/URLWithQueryBuildableFactory.swift
+++ b/Sources/Frisbee/Factories/URLWithQueryBuildableFactory.swift
@@ -1,0 +1,7 @@
+struct URLWithQueryBuildableFactory {
+
+    static func make() -> URLWithQueryBuildable {
+        return URLWithQueryBuilder()
+    }
+
+}

--- a/Sources/Frisbee/Interactors/ResultGenerator.swift
+++ b/Sources/Frisbee/Interactors/ResultGenerator.swift
@@ -2,11 +2,17 @@ import Foundation
 
 struct ResultGenerator<Entity: Decodable> {
 
-    static func generate(data: Data?, error: Error?) -> Result<Entity> {
+    private let decoder: FrisbeeDecodable
+
+    init(decoder: FrisbeeDecodable) {
+        self.decoder = decoder
+    }
+
+    func generate(data: Data?, error: Error?) -> Result<Entity> {
         if let data = data {
             let result: Result<Entity>
             do {
-                let entityDecoded = try JSONDecoder().decode(Entity.self, from: data)
+                let entityDecoded = try decoder.decode(Entity.self, from: data)
                 result = Result.success(entityDecoded)
             } catch {
                 let noDataError = FrisbeeError.noData

--- a/Sources/Frisbee/Interactors/URLWithQueryBuildable.swift
+++ b/Sources/Frisbee/Interactors/URLWithQueryBuildable.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol URLWithQueryBuildable {
+    func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL
+    func build<Query: Encodable>(withUrl url: URL, query: Query) throws -> URL
+}

--- a/Sources/Frisbee/Interactors/URLWithQueryBuilder.swift
+++ b/Sources/Frisbee/Interactors/URLWithQueryBuilder.swift
@@ -1,15 +1,20 @@
 import Foundation
 
-struct URLWithQueryBuilder {
+protocol URLWithQueryBuildable {
+    func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL
+    func build<Query: Encodable>(withUrl url: URL, query: Query) throws -> URL
+}
 
-    static func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL {
+struct URLWithQueryBuilder: URLWithQueryBuildable {
+
+    func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL {
         guard let actualUrl = URL(string: url) else {
             throw FrisbeeError.invalidUrl
         }
         return try build(withUrl: actualUrl, query: query)
     }
 
-    static func build<Query: Encodable>(withUrl url: URL, query: Query) throws -> URL {
+    func build<Query: Encodable>(withUrl url: URL, query: Query) throws -> URL {
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
         urlComponents?.queryItems = try QueryItemBuilder.build(withEntity: query)
 

--- a/Sources/Frisbee/Interactors/URLWithQueryBuilder.swift
+++ b/Sources/Frisbee/Interactors/URLWithQueryBuilder.swift
@@ -1,10 +1,5 @@
 import Foundation
 
-protocol URLWithQueryBuildable {
-    func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL
-    func build<Query: Encodable>(withUrl url: URL, query: Query) throws -> URL
-}
-
 struct URLWithQueryBuilder: URLWithQueryBuildable {
 
     func build<Query: Encodable>(withUrl url: String, query: Query) throws -> URL {

--- a/Sources/Frisbee/Requestables/NetworkGet.swift
+++ b/Sources/Frisbee/Requestables/NetworkGet.swift
@@ -6,7 +6,7 @@ typealias NetworkGetter = NetworkGet
 public class NetworkGet: Getable {
 
     let urlSession: URLSession
-    private let queryBuildable: URLWithQueryBuildable
+    private let queryBuilder: URLWithQueryBuildable
 
     public convenience init() {
         self.init(queryBuildable: URLWithQueryBuildableFactory.make(), urlSession: URLSessionFactory.make())
@@ -17,7 +17,7 @@ public class NetworkGet: Getable {
     }
 
     init(queryBuildable: URLWithQueryBuildable, urlSession: URLSession) {
-        self.queryBuildable = queryBuildable
+        self.queryBuilder = queryBuildable
         self.urlSession = urlSession
     }
 
@@ -43,7 +43,7 @@ public class NetworkGet: Getable {
     public func get<Entity: Decodable, Query: Encodable>(url: URL, query: Query,
                                                          onComplete: @escaping (Result<Entity>) -> Void) {
         do {
-            let url = try queryBuildable.build(withUrl: url, query: query)
+            let url = try queryBuilder.build(withUrl: url, query: query)
             makeRequest(url: url, onComplete: onComplete)
         } catch {
             return onComplete(.fail(FrisbeeError(error)))

--- a/Sources/Frisbee/Requestables/NetworkGet.swift
+++ b/Sources/Frisbee/Requestables/NetworkGet.swift
@@ -54,7 +54,7 @@ public class NetworkGet: Getable {
         let request = URLRequestFactory.make(.GET, url)
 
         let task = urlSession.dataTask(with: request) { data, _, error in
-            onComplete(ResultGenerator.generate(data: data, error: error))
+            onComplete(ResultGeneratorFactory.make().generate(data: data, error: error))
         }
 
         task.resume()

--- a/Sources/Frisbee/Requestables/NetworkGet.swift
+++ b/Sources/Frisbee/Requestables/NetworkGet.swift
@@ -39,11 +39,8 @@ public class NetworkGet: Getable {
         do {
             let url = try URLWithQueryBuilder.build(withUrl: url, query: query)
             makeRequest(url: url, onComplete: onComplete)
-        } catch where type(of: error) == FrisbeeError.self {
-            let error = error as? FrisbeeError ?? .unknown
-            return onComplete(.fail(error))
         } catch {
-            return onComplete(.fail(.other(localizedDescription: error.localizedDescription)))
+            return onComplete(.fail(FrisbeeError(error)))
         }
     }
 

--- a/Sources/Frisbee/Requestables/NetworkGet.swift
+++ b/Sources/Frisbee/Requestables/NetworkGet.swift
@@ -8,14 +8,12 @@ public class NetworkGet: Getable {
     let urlSession: URLSession
     private let queryBuildable: URLWithQueryBuildable
 
-    public init() {
-        self.urlSession = URLSessionFactory.make()
-        self.queryBuildable = URLWithQueryBuildableFactory.make()
+    public convenience init() {
+        self.init(queryBuildable: URLWithQueryBuildableFactory.make(), urlSession: URLSessionFactory.make())
     }
 
-    public init(urlSession: URLSession) {
-        self.urlSession = urlSession
-        self.queryBuildable = URLWithQueryBuildableFactory.make()
+    public convenience init(urlSession: URLSession) {
+        self.init(queryBuildable: URLWithQueryBuildableFactory.make(), urlSession: urlSession)
     }
 
     init(queryBuildable: URLWithQueryBuildable, urlSession: URLSession) {

--- a/Sources/Frisbee/Requestables/NetworkGet.swift
+++ b/Sources/Frisbee/Requestables/NetworkGet.swift
@@ -6,12 +6,20 @@ typealias NetworkGetter = NetworkGet
 public class NetworkGet: Getable {
 
     let urlSession: URLSession
+    private let queryBuildable: URLWithQueryBuildable
 
     public init() {
         self.urlSession = URLSessionFactory.make()
+        self.queryBuildable = URLWithQueryBuildableFactory.make()
     }
 
     public init(urlSession: URLSession) {
+        self.urlSession = urlSession
+        self.queryBuildable = URLWithQueryBuildableFactory.make()
+    }
+
+    init(queryBuildable: URLWithQueryBuildable, urlSession: URLSession) {
+        self.queryBuildable = queryBuildable
         self.urlSession = urlSession
     }
 
@@ -37,7 +45,7 @@ public class NetworkGet: Getable {
     public func get<Entity: Decodable, Query: Encodable>(url: URL, query: Query,
                                                          onComplete: @escaping (Result<Entity>) -> Void) {
         do {
-            let url = try URLWithQueryBuilder.build(withUrl: url, query: query)
+            let url = try queryBuildable.build(withUrl: url, query: query)
             makeRequest(url: url, onComplete: onComplete)
         } catch {
             return onComplete(.fail(FrisbeeError(error)))

--- a/Tests/FrisbeeTests/Entities/FrisbeeErrorTests.swift
+++ b/Tests/FrisbeeTests/Entities/FrisbeeErrorTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Frisbee
 import XCTest
+@testable import Frisbee
 
 class FrisbeeErrorTests: XCTestCase {
 
@@ -24,11 +24,29 @@ class FrisbeeErrorTests: XCTestCase {
         }
     }
 
+    func testInitFromInvalidURLErrorThenCreateFrisbeErrorInvalidURL() {
+        let error: Error = FrisbeeError.invalidUrl
+
+        let frisbeeError = FrisbeeError(error)
+
+        XCTAssertEqual(frisbeeError, .invalidUrl)
+    }
+
+    func testInitFromUnkownErrorThenCreateFrisbeErrorOtherWithLocalizedString() {
+        let error: Error = NSError(domain: "domain", code: 0)
+
+        let frisbeeError = FrisbeeError(error)
+
+        XCTAssertEqual(frisbeeError, .other(localizedDescription: error.localizedDescription))
+    }
+
     static var allTests = [
         ("testEquatableFromAllPossibleErrorsThenBeEqual",
          testEquatableFromAllPossibleErrorsThenBeEqual),
         ("testInequatableFromAllPossibleErrorsThenBeNotEqual",
-         testInequatableFromAllPossibleErrorsThenBeNotEqual)
+         testInequatableFromAllPossibleErrorsThenBeNotEqual),
+        ("testInitFromUnkownErrorThenCreateFrisbeErrorOtherWithLocalizedString",
+         testInitFromUnkownErrorThenCreateFrisbeErrorOtherWithLocalizedString)
     ]
 
 }

--- a/Tests/FrisbeeTests/Extensions/FrisbeeError+All.swift
+++ b/Tests/FrisbeeTests/Extensions/FrisbeeError+All.swift
@@ -3,8 +3,7 @@ import Frisbee
 
 extension FrisbeeError {
     static func all(error: Error) -> [FrisbeeError] {
-        return [FrisbeeError.invalidUrl, .invalidQuery,
-                .invalidEntity, .noData, .unknown,
+        return [FrisbeeError.invalidUrl, .invalidQuery, .invalidEntity, .noData,
                 .other(localizedDescription: error.localizedDescription)]
     }
 }

--- a/Tests/FrisbeeTests/Interactors/URLWithQueryBuilderTests.swift
+++ b/Tests/FrisbeeTests/Interactors/URLWithQueryBuilderTests.swift
@@ -3,6 +3,13 @@ import XCTest
 
 class URLWithQueryBuilderTests: XCTestCase {
 
+    private var urlWithQueryBuilder: URLWithQueryBuildable!
+
+    override func setUp() {
+        super.setUp()
+        urlWithQueryBuilder = URLWithQueryBuildableFactory.make()
+    }
+
     struct MovieQuery: Encodable {
         let page: Int
         let keyAccess: String
@@ -20,7 +27,7 @@ class URLWithQueryBuilderTests: XCTestCase {
             return XCTFail("Invalid URL")
         }
 
-        let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
+        let builtUrl = try? urlWithQueryBuilder.build(withUrl: url, query: query)
 
         XCTAssertTrue(builtUrl?.absoluteString.starts(with: url.absoluteString) ?? false)
         XCTAssertEqual("\(query.page)", getQueryValue(builtUrl?.absoluteString, "page"))
@@ -32,7 +39,7 @@ class URLWithQueryBuilderTests: XCTestCase {
         let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: nil)
         let url = "http://www.com.br"
 
-        let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
+        let builtUrl = try? urlWithQueryBuilder.build(withUrl: url, query: query)
 
         XCTAssertTrue(builtUrl?.absoluteString.starts(with: url) ?? false)
         XCTAssertEqual("\(query.page)", getQueryValue(builtUrl?.absoluteString, "page"))
@@ -46,7 +53,7 @@ class URLWithQueryBuilderTests: XCTestCase {
             return XCTFail("Invalid URL")
         }
 
-        let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
+        let builtUrl = try? urlWithQueryBuilder.build(withUrl: url, query: query)
 
         XCTAssertTrue(builtUrl?.absoluteString.starts(with: url.absoluteString) ?? false)
         XCTAssertEqual("\(query.page)", getQueryValue(builtUrl?.absoluteString, "page"))
@@ -58,7 +65,7 @@ class URLWithQueryBuilderTests: XCTestCase {
         let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: 10)
         let url = "http://www.com.br"
 
-        let builtUrl = try? URLWithQueryBuilder.build(withUrl: url, query: query)
+        let builtUrl = try? urlWithQueryBuilder.build(withUrl: url, query: query)
 
         XCTAssertTrue(builtUrl?.absoluteString.starts(with: url) ?? false)
         XCTAssertEqual("\(query.page)", getQueryValue(builtUrl?.absoluteString, "page"))
@@ -70,7 +77,7 @@ class URLWithQueryBuilderTests: XCTestCase {
         let query = MovieQuery(page: 1, keyAccess: "a1d13so979", optionalInt: 10)
         let url = "http://www.çøµ.∫®"
 
-        XCTAssertThrowsError(try URLWithQueryBuilder.build(withUrl: url, query: query)) {
+        XCTAssertThrowsError(try urlWithQueryBuilder.build(withUrl: url, query: query)) {
             XCTAssertEqual($0 as? FrisbeeError, FrisbeeError.invalidUrl)
         }
     }


### PR DESCRIPTION
Created an `init` for `FrisbeError` and remove some error handling in `NetworkGet`. With that is more easy to test error handling and `.unknown` error is unnecessary.