### PR TITLE
Add JSON (de/en)coder to Adapter's initializers

### DIFF
--- a/Sources/Frisbee/Adapters/DecoderJSONAdapter.swift
+++ b/Sources/Frisbee/Adapters/DecoderJSONAdapter.swift
@@ -2,8 +2,14 @@ import Foundation
 
 final class DecoderJSONAdapter: DecodableAdapter {
 
+    let decoder: JSONDecoder
+
+    init(decoder: JSONDecoder = JSONDecoder()) {
+        self.decoder = decoder
+    }
+
     func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
-        return try JSONDecoder().decode(type, from: data)
+        return try decoder.decode(type, from: data)
     }
 
 }

--- a/Sources/Frisbee/Adapters/EncoderJSONAdapter.swift
+++ b/Sources/Frisbee/Adapters/EncoderJSONAdapter.swift
@@ -1,7 +1,14 @@
 import Foundation
 
 final class EncoderJSONAdapter: EncodableAdapter {
+
+    let encoder: JSONEncoder
+
+    init(encoder: JSONEncoder = JSONEncoder()) {
+        self.encoder = encoder
+    }
+
     func encode<T: Encodable>(_ value: T) throws -> Data {
-        return try JSONEncoder().encode(value)
+        return try encoder.encode(value)
     }
 }


### PR DESCRIPTION
JSON (de/en)coders can be configured with some other options, this just allows them to be inserted before initializing the adapters

More work should be done on whoever uses them